### PR TITLE
Adds a docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+**/__pycache__
+.env
+**/.pytest_cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.7-stretch
+
+COPY . /app
+WORKDIR /app
+
+RUN pip install -r requirements.txt
+
+ENV FLASK_APP app.py
+CMD ["python", "-m", "flask", "run"]

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,6 @@ test:
 
 run:
 	FLASK_ENV=development FLASK_CONFIGURATION=dev FLASK_APP=app.py python -m flask run
+
+docker:
+	docker build -t datatrust:local .


### PR DESCRIPTION
Allows for running datatrust via docker image (does not mount local volume). Built mainly to simulate builds on TravisCI to catch issues before committing code.